### PR TITLE
Add fort background image to header

### DIFF
--- a/about.html
+++ b/about.html
@@ -9,7 +9,6 @@
 <body>
     <header>
         <h1>No Man's Fort</h1>
-        <img src="images/300px-Monkey_Puppet.jpeg" alt="Monkey Puppet" class="header-img">
         <nav>
             <ul>
                 <li><a href="index.html">Home</a></li>

--- a/contact.html
+++ b/contact.html
@@ -9,7 +9,6 @@
 <body>
     <header>
         <h1>No Man's Fort</h1>
-        <img src="images/300px-Monkey_Puppet.jpeg" alt="Monkey Puppet" class="header-img">
         <nav>
             <ul>
                 <li><a href="index.html">Home</a></li>

--- a/events.html
+++ b/events.html
@@ -9,7 +9,6 @@
 <body>
     <header>
         <h1>No Man's Fort</h1>
-        <img src="images/300px-Monkey_Puppet.jpeg" alt="Monkey Puppet" class="header-img">
         <nav>
             <ul>
                 <li><a href="index.html">Home</a></li>

--- a/experience.html
+++ b/experience.html
@@ -9,7 +9,6 @@
 <body>
     <header>
         <h1>No Man's Fort</h1>
-        <img src="images/300px-Monkey_Puppet.jpeg" alt="Monkey Puppet" class="header-img">
         <nav>
             <ul>
                 <li><a href="index.html">Home</a></li>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
 <body>
     <header>
         <h1>No Man's Fort</h1>
-        <img src="images/300px-Monkey_Puppet.jpeg" alt="Monkey Puppet" class="header-img">
         <nav>
             <ul>
                 <li><a href="index.html">Home</a></li>

--- a/invest.html
+++ b/invest.html
@@ -9,7 +9,6 @@
 <body>
     <header>
         <h1>No Man's Fort</h1>
-        <img src="images/300px-Monkey_Puppet.jpeg" alt="Monkey Puppet" class="header-img">
         <nav>
             <ul>
                 <li><a href="index.html">Home</a></li>

--- a/styles/main.css
+++ b/styles/main.css
@@ -6,16 +6,16 @@ body {
 }
 
 header {
-    background-color: #333;
+    background-color: #333; /* fallback */
+    background-image: url("../images/No-Mans-Land-Fort.jpg");
+    background-size: cover;
+    background-position: center;
     color: #fff;
     padding: 1rem;
     display: flex;
     align-items: center;
     gap: 1rem;
-}
-
-header img.header-img {
-    height: 50px;
+    min-height: 150px;
 }
 
 header nav ul {


### PR DESCRIPTION
## Summary
- remove placeholder header images from each page
- apply No-Mans-Land-Fort.jpg as a full-width background for the header
- set a minimum header height for better aspect ratio

## Testing
- `npm test` *(fails: could not find package.json)*
- `htmlhint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684876e6dfb4832891d2a5c6b4a81e05